### PR TITLE
Return empty array when golangci-lint return empty

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -30,22 +30,22 @@ type langHandler struct {
 }
 
 func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
+	diagnostics := make([]Diagnostic, 0)
+
 	//nolint:gosec
 	cmd := exec.Command(h.command[0], h.command[1:]...)
 
 	b, err := cmd.CombinedOutput()
 	if err == nil {
-		return nil, nil
+		return diagnostics, nil
 	}
 
 	var result GolangCILintResult
 	if err := json.Unmarshal(b, &result); err != nil {
-		return nil, err
+		return diagnostics, err
 	}
 
 	h.logger.DebugJSON("golangci-lint-langserver: result:", result)
-
-	diagnostics := make([]Diagnostic, 0)
 
 	for _, issue := range result.Issues {
 		issue := issue


### PR DESCRIPTION
Hi @nametake , thanks for the nice language server!

When golangci-lint doesn't returns an error, this will be returned as:

```json
{"uri":"file:///path/to/file.go","diagnostics":null}
```

But I think diagnostics should be an empty array, not null. So, I fixed it.
Please feel free to merge this PR. Thanks.