### PR TITLE
Fix response to initialize

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -131,7 +131,11 @@ func (h *langHandler) handleInitialize(_ context.Context, conn *jsonrpc2.Conn, r
 
 	return InitializeResult{
 		Capabilities: ServerCapabilities{
-			TextDocumentSync: TDSKFull,
+			TextDocumentSync: TextDocumentSyncOptions{
+				Change:    TDSKNone,
+				OpenClose: true,
+				Save:      true,
+			},
 		},
 	}, nil
 }

--- a/lsp.go
+++ b/lsp.go
@@ -29,14 +29,22 @@ type CompletionProvider struct {
 	TriggerCharacters []string `json:"triggerCharacters"`
 }
 
+type TextDocumentSyncOptions struct {
+	OpenClose         bool                 `json:"openClose,omitempty"`
+	Change            TextDocumentSyncKind `json:"change,omitempty"`
+	WillSave          bool                 `json:"willSave,omitempty"`
+	WillSaveWaitUntil bool                 `json:"willSaveWaitUntil,omitempty"`
+	Save              bool                 `json:"save,omitempty"`
+}
+
 type ServerCapabilities struct {
-	TextDocumentSync           TextDocumentSyncKind `json:"textDocumentSync,omitempty"`
-	CompletionProvider         *CompletionProvider  `json:"completionProvider,omitempty"`
-	DocumentSymbolProvider     bool                 `json:"documentSymbolProvider,omitempty"`
-	DefinitionProvider         bool                 `json:"definitionProvider,omitempty"`
-	DocumentFormattingProvider bool                 `json:"documentFormattingProvider,omitempty"`
-	HoverProvider              bool                 `json:"hoverProvider,omitempty"`
-	CodeActionProvider         bool                 `json:"codeActionProvider,omitempty"`
+	TextDocumentSync           TextDocumentSyncOptions `json:"textDocumentSync,omitempty"`
+	CompletionProvider         *CompletionProvider     `json:"completionProvider,omitempty"`
+	DocumentSymbolProvider     bool                    `json:"documentSymbolProvider,omitempty"`
+	DefinitionProvider         bool                    `json:"definitionProvider,omitempty"`
+	DocumentFormattingProvider bool                    `json:"documentFormattingProvider,omitempty"`
+	HoverProvider              bool                    `json:"hoverProvider,omitempty"`
+	CodeActionProvider         bool                    `json:"codeActionProvider,omitempty"`
 }
 
 type TextDocumentItem struct {


### PR DESCRIPTION
golangci-lint-langserver doesn't really handle didChange, and when
TextDocumentSync is set to a number, it affects the behavior of
didChange. Without this change, more strict clients won't send the
textDocument/didSave notification.

With this change, I'm able to use golangci-lint-langserver with neovim's
builtin lsp client.