### PR TITLE
Execute golangci-lint in target document's directory

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strings"
+	"path/filepath"
 
 	"github.com/sourcegraph/jsonrpc2"
 )
@@ -32,8 +32,12 @@ type langHandler struct {
 func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	diagnostics := make([]Diagnostic, 0)
 
+	path := uriToPath(string(uri))
+	dir, file := filepath.Split(path)
+
 	//nolint:gosec
 	cmd := exec.Command(h.command[0], h.command[1:]...)
+	cmd.Dir = dir
 
 	b, err := cmd.CombinedOutput()
 	if err == nil {
@@ -50,7 +54,7 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	for _, issue := range result.Issues {
 		issue := issue
 
-		if strings.TrimPrefix(string(uri), h.rootURI+"/") != issue.Pos.Filename {
+		if file != issue.Pos.Filename {
 			continue
 		}
 

--- a/uri.go
+++ b/uri.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+func uriToPath(uri string) string {
+	switch {
+	case strings.HasPrefix(uri, "file:///"):
+		uri = uri[len("file://"):]
+	case strings.HasPrefix(uri, "file://"):
+		uri = uri[len("file:/"):]
+	}
+
+	if path, err := url.PathUnescape(uri); err == nil {
+		uri = path
+	}
+
+	if isWindowsDriveURIPath(uri) {
+		uri = strings.ToUpper(string(uri[1])) + uri[2:]
+	}
+
+	return filepath.FromSlash(uri)
+}
+
+func isWindowsDriveURIPath(uri string) bool {
+	//nolint:gomnd
+	if len(uri) < 4 {
+		return false
+	}
+
+	return uri[0] == '/' && unicode.IsLetter(rune(uri[1])) && uri[2] == ':'
+}


### PR DESCRIPTION
Fixed golangci-lint-server doesn't report anything if current working
directory is not the root directory.

Note that `issue.Pos.Filename` may contain backslashes on Windows, which
would cause previous if-check always fails. This PR makes the problem
gone.

May have better performance.