### PR TITLE
Added doc to install golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ golangci-lint-langserver is [golangci-lint](https://github.com/golangci/golangci
 
 ## Installation
 
+Install [golangci-lint](https://golangci-lint.run).
+
 ```console
 go get github.com/nametake/golangci-lint-langserver
 ```


### PR DESCRIPTION
Perhaps an issue with no golangci-lint.

https://github.com/nametake/golangci-lint-langserver/issues/8
https://github.com/nametake/golangci-lint-langserver/issues/17