### PR TITLE
Add option to return all diagnostic instead of only current file

### DIFF
--- a/lsp.go
+++ b/lsp.go
@@ -8,7 +8,8 @@ type InitializeParams struct {
 }
 
 type InitializationOptions struct {
-	Command []string
+	Command []string `json:"command,omitempty"`
+	ShowAll bool     `json:"show_all,omitempty"`
 }
 
 type InitializeResult struct {


### PR DESCRIPTION
Also uses `golangci-lint run` if no command was specified