### PR TITLE
docs: updated readme for neovim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ augroup END
 
 ### Configuration for [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
 
-**Requires [Neovim HEAD/nightly](https://github.com/neovim/neovim/releases/tag/nightly) (v0.5 prerelease).**
+**Requires Neovim [v0.6.1](https://github.com/neovim/neovim/releases/tag/v0.6.1) or [nightly](https://github.com/neovim/neovim/releases/tag/nightly).**
 
 ```lua
 local lspconfig = require 'lspconfig'
@@ -79,8 +79,8 @@ if not configs.golangcilsp then
 		};
 	}
 end
-lspconfig.golangcilsp.setup {
-	filetypes = {'go'}
+lspconfig.golangci_lint_ls.setup {
+	filetypes = {'go','gomod'}
 }
 ```
 


### PR DESCRIPTION
Just made some minor doc changes to the README regarding the nvim-lspconfig setup. The example config is a little out of date and doesn't work with the latest nvim setup. Bumped up the neovim version to reflect the requirements for nvim-lspconfig and the correct LSP name for setting it up.