### PR TITLE
fix: workspace/didChangeConfiguration  error

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -128,6 +128,8 @@ func (h *langHandler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *json
 		return h.handleTextDocumentDidChange(ctx, conn, req)
 	case "textDocument/didSave":
 		return h.handleTextDocumentDidSave(ctx, conn, req)
+	case "workspace/didChangeConfiguration":
+		return h.handlerWorkspaceDidChangeConfiguration(ctx, conn, req)
 	}
 
 	return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeMethodNotFound, Message: fmt.Sprintf("method not supported: %s", req.Method)}
@@ -187,5 +189,9 @@ func (h *langHandler) handleTextDocumentDidSave(_ context.Context, _ *jsonrpc2.C
 
 	h.request <- params.TextDocument.URI
 
+	return nil, nil
+}
+
+func (h *langHandler) handlerWorkspaceDidChangeConfiguration(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
 	return nil, nil
 }


### PR DESCRIPTION
golangci-lint-langserver  doesn't have `workspace/didChangeConfiguration` handler.
So the following error was outputted.

```
Sat 20 Aug 2022 05:31:18 PM JST:["<---(stderr)",1,"golangci-lint-langserver","golangci-lint-langserver: connections opened\n2022/08/20 17:31:18 jsonrpc2 handler: notification \"workspace/didChangeConfiguration\" handling error: jsonrpc2: code -32601 message: method not supported: workspace/didChangeConfiguration\n"]
```

golangci-lint-langserver worked fine,  but I add `workspace/didChangeConfiguration` handler to avoid error log.
