### PR TITLE
Respect the severity reported in the issue,

### DIFF
--- a/golangci-lint.go
+++ b/golangci-lint.go
@@ -1,8 +1,11 @@
 package main
 
+import "strings"
+
 type Issue struct {
 	FromLinter  string      `json:"FromLinter"`
 	Text        string      `json:"Text"`
+	Severity    string      `json:"Severity"`
 	SourceLines []string    `json:"SourceLines"`
 	Replacement interface{} `json:"Replacement"`
 	Pos         struct {
@@ -11,10 +14,32 @@ type Issue struct {
 		Line     int    `json:"Line"`
 		Column   int    `json:"Column"`
 	} `json:"Pos"`
-	LineRange struct {
+	ExpectNoLint         bool   `json:"ExpectNoLint"`
+	ExpectedNoLintLinter string `json:"ExpectedNoLintLinter"`
+	LineRange            struct {
 		From int `json:"From"`
 		To   int `json:"To"`
 	} `json:"LineRange,omitempty"`
+}
+
+func (i Issue) DiagSeverity() DiagnosticSeverity {
+	if i.Severity == "" {
+		// TODO: How to get default-severity from .golangci.yml, if available?
+		i.Severity = defaultSeverity
+	}
+
+	switch strings.ToLower(i.Severity) {
+	case "err", "error":
+		return DSError
+	case "warn", "warning":
+		return DSWarning
+	case "info", "information":
+		return DSInformation
+	case "hint":
+		return DSHint
+	default:
+		return DSWarning
+	}
 }
 
 //nolint:unused,deadcode

--- a/handler.go
+++ b/handler.go
@@ -60,13 +60,12 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 			continue
 		}
 
-		//nolint:gomnd
 		d := Diagnostic{
 			Range: Range{
 				Start: Position{Line: issue.Pos.Line - 1, Character: issue.Pos.Column - 1},
 				End:   Position{Line: issue.Pos.Line - 1, Character: issue.Pos.Column - 1},
 			},
-			Severity: DSWarning,
+			Severity: issue.DiagSeverity(),
 			Source:   &issue.FromLinter,
 			Message:  h.diagnosticMessage(&issue),
 		}

--- a/main.go
+++ b/main.go
@@ -8,9 +8,12 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
+var defaultSeverity = "Warn"
+
 func main() {
 	debug := flag.Bool("debug", false, "output debug log")
 	noLinterName := flag.Bool("nolintername", false, "don't show a linter name in message")
+	flag.StringVar(&defaultSeverity, "severity", defaultSeverity, "Default severity to use. Choices are: Err(or), Warn(ing), Info(rmation) or Hint")
 
 	flag.Parse()
 


### PR DESCRIPTION
 and allow end users to set a default severity. If none are present, it defaults to Warning (as it used to be).

Fixes #26 