### PR TITLE
docs: update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ golangci-lint-langserver is [golangci-lint](https://github.com/golangci/golangci
 Install [golangci-lint](https://golangci-lint.run).
 
 ```console
-go get github.com/nametake/golangci-lint-langserver
+go install github.com/nametake/golangci-lint-langserver@latest
 ```
 
 ## Options


### PR DESCRIPTION
Since Go 1.18, you can no longer install binaries with `go get`.
This PR replaces it with the new `go install` command added in Go 1.16.

https://go.dev/doc/go1.18#go-get