### PR TITLE
Add an option to run golangci-lint from the directory of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ go install github.com/nametake/golangci-lint-langserver@latest
         output debug log
   -nolintername
         don't show a linter name in message
+  -from-config-dir
+        run linter from .golangci-lint.yml directory
 ```
+
+## Options
+
+`-from-config-dir` makes the `golangci-lint` run from the directory with configuration file.
+This makes relative paths in the configuration path work at the cost of small slowdown.
+
+Use this option if your `.golangci-lint.yml` file contains relative paths or if `golangci-lint`
+[refuses to run from a subdirectory of a project due to some other reason](https://github.com/golangci/golangci-lint/issues/3717).
 
 ## Configuration
 

--- a/main.go
+++ b/main.go
@@ -13,13 +13,14 @@ var defaultSeverity = "Warn"
 func main() {
 	debug := flag.Bool("debug", false, "output debug log")
 	noLinterName := flag.Bool("nolintername", false, "don't show a linter name in message")
+	fromConfigDir := flag.Bool("from-config-dir", false, "run linter from .golangci-lint.yml directory")
 	flag.StringVar(&defaultSeverity, "severity", defaultSeverity, "Default severity to use. Choices are: Err(or), Warn(ing), Info(rmation) or Hint")
 
 	flag.Parse()
 
 	logger := newStdLogger(*debug)
 
-	handler := NewHandler(logger, *noLinterName)
+	handler := NewHandler(logger, *noLinterName, *fromConfigDir)
 
 	var connOpt []jsonrpc2.ConnOpt
 


### PR DESCRIPTION
golangci-lint has issues running in subdirectories of the project, e.g. golangci/golangci-lint#3656, golangci/golangci-lint#3717, so running it from the directory where configuration file is located is the only option for some projects.

Make it work as an option, because not every project triggers this problem in golangci-lint, so for these projects overhead of looking up directory of config file and adjusting the paths after is not needed.