### PR TITLE
Avoid returning negative positions

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -91,8 +91,14 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 
 		d := Diagnostic{
 			Range: Range{
-				Start: Position{Line: issue.Pos.Line - 1, Character: issue.Pos.Column - 1},
-				End:   Position{Line: issue.Pos.Line - 1, Character: issue.Pos.Column - 1},
+				Start: Position{
+					Line:      max(issue.Pos.Line-1, 0),
+					Character: max(issue.Pos.Column-1, 0),
+				},
+				End: Position{
+					Line:      max(issue.Pos.Line-1, 0),
+					Character: max(issue.Pos.Column-1, 0),
+				},
 			},
 			Severity: issue.DiagSeverity(),
 			Source:   &issue.FromLinter,
@@ -102,6 +108,13 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	}
 
 	return diagnostics, nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func (h *langHandler) diagnosticMessage(issue *Issue) string {


### PR DESCRIPTION
According to the LSP spec, the line and character must both be unsigned integers. The spec also specifically calls out that `-1` is not supported: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position

With some code structures, it is possible to produce an error such as the following from `golangci-lint run --out-format=json`:

```json
{
  "FromLinter": "typecheck",
  "Text": ": # github.com/my/package [github.com/my/package.test]\n./main.go:31:2: undefined: asdf",
  "Severity": "",
  "SourceLines": [
    "package main"
  ],
  "Replacement": null,
  "Pos": {
    "Filename": "main.go",
    "Offset": 0,
    "Line": 1,
    "Column": 0
  },
  "ExpectNoLint": false,
  "ExpectedNoLintLinter": ""
}
```

This ultimately does result in some issues with tooling compatibility, for example: https://github.com/folke/trouble.nvim/issues/224#issuecomment-1495410321

By preventing the number from dropping below zero, this class of error should no longer be present.