### PR TITLE
Add skip lint on non-go files

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -53,6 +53,12 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	path := uriToPath(string(uri))
 	dir, file := filepath.Split(path)
 
+	if !strings.HasSuffix(file, ".go") &&
+		!strings.HasSuffix(file, ".mod") &&
+		!strings.HasSuffix(file, ".sum") {
+		return diagnostics, nil
+	}
+
 	args := make([]string, 0, len(h.command))
 	args = append(args, h.command[1:]...)
 	args = append(args, dir)


### PR DESCRIPTION
Some clients send everything to the language server, regardless of the file extension. For example, according to the logs, Zed Editor sends every opened file to lsp. I suggest not running the linter if the file sent is not a go file.