### PR TITLE
fix: ignore 'no go files to analyze' error for emtpy folders

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -33,10 +33,17 @@ type langHandler struct {
 	rootDir string
 }
 
+// As defined in the `golangci-lint` source code:
+// https://github.com/golangci/golangci-lint/blob/main/pkg/exitcodes/exitcodes.go#L24
+const GoNoFilesExitCode = 5
+
 func (h *langHandler) errToDiagnostics(err error) []Diagnostic {
 	var message string
 	switch e := err.(type) {
 	case *exec.ExitError:
+		if e.ExitCode() == GoNoFilesExitCode {
+			return []Diagnostic{}
+		}
 		message = string(e.Stderr)
 	default:
 		h.logger.DebugJSON("golangci-lint-langserver: errToDiagnostics message", message)


### PR DESCRIPTION
When using the lang server from the Zed extension (https://github.com/zed-extensions/golangci-lint) I got errors for the first line of all files in folders that doesn't have Go source files. This fix checks the exit code as defined by `golangci-lint` (https://github.com/golangci/golangci-lint/blob/main/pkg/exitcodes/exitcodes.go#L24), but it should be noted that this exit code might not be stable as it's defined as an `iota` and not with a static code.