### PR TITLE
feat: update golangci-lint params for v2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ coc-settings.json
       "command": "golangci-lint-langserver",
       "filetypes": ["go"],
       "initializationOptions": {
-        "command": ["golangci-lint", "run", "--out-format", "json", "--issues-exit-code=1"]
-      }
+        "command": ["golangci-lint", "run", "--output.json.path", "stdout", "--show-stats=false", "--issues-exit-code=1"]
     }
   }
 }
@@ -52,7 +51,7 @@ augroup vim_lsp_golangci_lint_langserver
   autocmd User lsp_setup call lsp#register_server({
       \ 'name': 'golangci-lint-langserver',
       \ 'cmd': {server_info->['golangci-lint-langserver']},
-      \ 'initialization_options': {'command': ['golangci-lint', 'run', '--out-format', 'json', '--issues-exit-code=1']},
+      \ 'initialization_options': {'command': ['golangci-lint', 'run', '--output.json.path', 'stdout', '--show-stats=false', '--issues-exit-code=1']},
       \ 'whitelist': ['go'],
       \ })
 augroup END
@@ -74,8 +73,7 @@ if not configs.golangcilsp then
 			cmd = {'golangci-lint-langserver'},
 			root_dir = lspconfig.util.root_pattern('.git', 'go.mod'),
 			init_options = {
-					command = { "golangci-lint", "run", "--out-format", "json", "--issues-exit-code=1" };
-			}
+					command = { "golangci-lint", "run", "--output.json.path", "stdout", "--show-stats=false", "--issues-exit-code=1" };
 		};
 	}
 end
@@ -106,5 +104,10 @@ language-servers = [ "gopls", "golangci-lint-lsp" ]
 command = "golangci-lint-langserver"
 
 [language-server.golangci-lint-lsp.config]
-command = ["golangci-lint", "run", "--out-format", "json", "--issues-exit-code=1"]
+command = ["golangci-lint", "run", "--output.json.path", "stdout", "--show-stats=false", "--issues-exit-code=1"]
 ```
+
+## golangci-lint Version Compatibility
+
+- For golangci-lint v2+: Use `--output.json.path stdout --show-stats=false` parameters
+- For golangci-lint v1: Use `--out-format json` parameter


### PR DESCRIPTION
Update golangci-lint command parameters across config examples to support version 2+, which requires different output formatting options. Add version compatibility notes to clarify parameter differences between golangci-lint v1 and v2+.