### PR TITLE
refactor: remove unnecessary code for modern Go

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -83,8 +83,6 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	h.logger.DebugJSON("golangci-lint-langserver: result:", result)
 
 	for _, issue := range result.Issues {
-		issue := issue
-
 		if file != issue.Pos.Filename {
 			continue
 		}
@@ -108,13 +106,6 @@ func (h *langHandler) lint(uri DocumentURI) ([]Diagnostic, error) {
 	}
 
 	return diagnostics, nil
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func (h *langHandler) diagnosticMessage(issue *Issue) string {


### PR DESCRIPTION
`issue := issue` and `max` are not needed for Go 1.23.

See https://go.dev/blog/loopvar-preview and https://pkg.go.dev/builtin#max